### PR TITLE
Support for JVM binding

### DIFF
--- a/codebase/src/java/wantest/wantest/Federate.java
+++ b/codebase/src/java/wantest/wantest/Federate.java
@@ -33,13 +33,12 @@ import hla.rti1516e.ResignAction;
 import hla.rti1516e.RtiFactoryFactory;
 import hla.rti1516e.exceptions.*;
 
-import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
 
 import static wantest.Handles.*;
 import wantest.config.Configuration;
+import wantest.config.LoggingConfigurator;
 import wantest.latency.LatencyDriver;
 import wantest.throughput.ThroughputDriver;
 
@@ -63,12 +62,11 @@ public class Federate
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	public Federate( String[] args )
+	public Federate( Configuration configuration )
 	{
 		// logging and configuration
+		this.configuration = configuration;
 		initializeLogging();
-		this.configuration = new Configuration();
-		this.configuration.loadCommandLine( args );
 
 		this.rtiamb = null; // created during createAndJoinFederate()
 		this.fedamb = null; // created during createAndJoinFederate()
@@ -120,16 +118,13 @@ public class Federate
 	 */
 	private void initializeLogging()
 	{
-		this.logger = Logger.getLogger( "wantest" ); 
+		LoggingConfigurator.initializeLogging();
+		this.logger = LoggingConfigurator.getLogger( configuration.getFederateName() ); 
 		this.logger.setLevel( Level.INFO );
 
-		// create the appender
-		PatternLayout layout = new PatternLayout( "%-5p [%t] %c: %x%m%n" );
-		ConsoleAppender appender = new ConsoleAppender( layout, ConsoleAppender.SYSTEM_OUT );
-		appender.setThreshold( Level.TRACE ); // output restricted at logger level, not appender
-
-		// attach the appender		
-		logger.addAppender( appender );
+		// this is a jvm federation, but we are not the master, so no logger for us
+		if( configuration.isJvmFederation() && !configuration.isJvmMaster() )
+			this.logger.setLevel( Level.OFF );
 	}
 
 	private IDriver loadDriver() throws Exception

--- a/codebase/src/java/wantest/wantest/Federate.java
+++ b/codebase/src/java/wantest/wantest/Federate.java
@@ -285,7 +285,10 @@ public class Federate
 		{
 			// let the RTI work for a bit while we wait to discover the
 			// objects registered by the remote federates
-			rtiamb.evokeMultipleCallbacks( 1.0, 1.0 );
+			if( configuration.isImmediateCallback() )
+				Utils.sleep( 500 );
+			else
+				rtiamb.evokeMultipleCallbacks( 1.0, 1.0 );
 
 			// check to see who turned up
 			for( TestFederate federate : storage.getPeers() )

--- a/codebase/src/java/wantest/wantest/Main.java
+++ b/codebase/src/java/wantest/wantest/Main.java
@@ -20,7 +20,11 @@
  */
 package wantest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import wantest.Federate;
+import wantest.config.Configuration;
 
 public class Main
 {
@@ -39,13 +43,71 @@ public class Main
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-	
+	private void executeJvmFederation( Configuration configuration )
+	{
+		System.setProperty( "portico.connection", "jvm" );
+		
+		String masterFederate = configuration.getFederateName();
+		List<String> allFederates = new ArrayList<String>();
+		allFederates.add( masterFederate );
+		allFederates.addAll( configuration.getPeers() );
+		
+		for( String name : allFederates )
+		{
+			// create a new configuration object for each of the federates so
+			// that they have the proper name and peer list
+			List<String> peers = new ArrayList<String>( allFederates );
+			peers.remove( name );
+			Configuration local = configuration.copy( name, peers );
+			
+			// set us up as the master if that is the case
+			if( masterFederate.equals(name) )
+				local.setJvmMaster( true );
+			
+			// run the thing
+			FederateRunner runner = new FederateRunner( local );
+			Thread thread = new Thread( runner, name );
+			thread.start();
+		}
+	}
 
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------
 	public static void main( String[] args ) throws Exception
 	{
-		new Federate(args).execute();
+		// load the configuration so we can tell if this is a JVM federation or not
+		Configuration configuration = new Configuration();
+		configuration.loadCommandLine( args );
+
+		if( configuration.isJvmFederation() )
+			new Main().executeJvmFederation( configuration );
+		else		
+			new Federate(configuration).execute();
+	}
+	
+
+	///////////////////////////////////////////////////////////////////////////////////
+	////////////// Private Inner Class: FederateThread ////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	public class FederateRunner implements Runnable
+	{
+		private Configuration configuration;
+		public FederateRunner( Configuration configuration )
+		{
+			this.configuration = configuration;
+		}
+		
+		public void run()
+		{
+			try
+			{
+				new Federate(configuration).execute();
+			}
+			catch( Exception e )
+			{
+				e.printStackTrace();
+			}
+		}
 	}
 }

--- a/codebase/src/java/wantest/wantest/Main.java
+++ b/codebase/src/java/wantest/wantest/Main.java
@@ -58,14 +58,26 @@ public class Main
 			// that they have the proper name and peer list
 			List<String> peers = new ArrayList<String>( allFederates );
 			peers.remove( name );
-			Configuration local = configuration.copy( name, peers );
+			final Configuration local = configuration.copy( name, peers );
 			
 			// set us up as the master if that is the case
 			if( masterFederate.equals(name) )
 				local.setJvmMaster( true );
 			
 			// run the thing
-			FederateRunner runner = new FederateRunner( local );
+			Runnable runner = new Runnable()
+			{
+				public void run()
+				{
+					try
+					{
+						new Federate(local).execute();
+					}
+					catch( Exception e ){ e.printStackTrace(); }
+				}
+			};
+			
+			//FederateRunner runner = new FederateRunner( local );
 			Thread thread = new Thread( runner, name );
 			thread.start();
 		}
@@ -86,28 +98,4 @@ public class Main
 			new Federate(configuration).execute();
 	}
 	
-
-	///////////////////////////////////////////////////////////////////////////////////
-	////////////// Private Inner Class: FederateThread ////////////////////////////////
-	///////////////////////////////////////////////////////////////////////////////////
-	public class FederateRunner implements Runnable
-	{
-		private Configuration configuration;
-		public FederateRunner( Configuration configuration )
-		{
-			this.configuration = configuration;
-		}
-		
-		public void run()
-		{
-			try
-			{
-				new Federate(configuration).execute();
-			}
-			catch( Exception e )
-			{
-				e.printStackTrace();
-			}
-		}
-	}
 }

--- a/codebase/src/java/wantest/wantest/config/LoggingConfigurator.java
+++ b/codebase/src/java/wantest/wantest/config/LoggingConfigurator.java
@@ -1,0 +1,72 @@
+/*
+ *   Copyright 2015 Calytrix Technologies
+ *
+ *   This file is part of wantest.
+ *
+ *   NOTICE:  All information contained herein is, and remains
+ *            the property of Calytrix Technologies Pty Ltd.
+ *            The intellectual and technical concepts contained
+ *            herein are proprietary to Calytrix Technologies Pty Ltd.
+ *            Dissemination of this information or reproduction of
+ *            this material is strictly forbidden unless prior written
+ *            permission is obtained from Calytrix Technologies Pty Ltd.
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+package wantest.config;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+
+public class LoggingConfigurator
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	private static volatile boolean CONFIGURED = false;
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	private LoggingConfigurator() {}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static synchronized void initializeLogging()
+	{
+		if( CONFIGURED )
+			return;
+
+		// create the appender
+		PatternLayout layout = new PatternLayout( "%-5p [%t] %c: %x%m%n" );
+		ConsoleAppender appender = new ConsoleAppender( layout, ConsoleAppender.SYSTEM_OUT );
+		appender.setThreshold( Level.TRACE ); // output restricted at logger level, not appender
+		
+		Logger logger = Logger.getLogger( "wantest" );
+		logger.addAppender( appender );
+		logger.setLevel( Level.INFO );
+		
+		CONFIGURED = true;
+	}
+	
+	public static Logger getLogger( String federateName )
+	{
+		return Logger.getLogger( "wantest."+federateName );
+	}
+}

--- a/codebase/src/java/wantest/wantest/latency/LatencyDriver.java
+++ b/codebase/src/java/wantest/wantest/latency/LatencyDriver.java
@@ -31,6 +31,7 @@ import wantest.IDriver;
 import wantest.Storage;
 import wantest.Utils;
 import wantest.config.Configuration;
+import wantest.config.LoggingConfigurator;
 import wantest.events.LatencyEvent;
 
 public class LatencyDriver implements IDriver
@@ -65,7 +66,7 @@ public class LatencyDriver implements IDriver
 	                     Storage storage )
 	    throws RTIexception
 	{
-		logger = Logger.getLogger( "wantest" );
+		logger = LoggingConfigurator.getLogger( configuration.getFederateName() );
 		this.configuration = configuration;
 		this.rtiamb = rtiamb;
 		this.fedamb = fedamb;

--- a/codebase/src/java/wantest/wantest/latency/LatencyReportGenerator.java
+++ b/codebase/src/java/wantest/wantest/latency/LatencyReportGenerator.java
@@ -56,7 +56,7 @@ public class LatencyReportGenerator
 	//----------------------------------------------------------
 	public LatencyReportGenerator( Storage storage )
 	{
-		this.logger = Logger.getLogger( "wantest" );
+		this.logger = Logger.getLogger( "wantest" ); // TODO Fix me for JVM federations
 		this.storage = storage;
 	}
 

--- a/codebase/src/java/wantest/wantest/throughput/ThroughputDriver.java
+++ b/codebase/src/java/wantest/wantest/throughput/ThroughputDriver.java
@@ -499,6 +499,7 @@ public class ThroughputDriver implements IDriver
 	{
 		return "Throughput Test";
 	}
+
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/wantest/wantest/throughput/ThroughputDriver.java
+++ b/codebase/src/java/wantest/wantest/throughput/ThroughputDriver.java
@@ -37,6 +37,7 @@ import wantest.TestFederate;
 import wantest.TestObject;
 import wantest.Utils;
 import wantest.config.Configuration;
+import wantest.config.LoggingConfigurator;
 import hla.rti1516e.AttributeHandleValueMap;
 import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.ParameterHandleValueMap;
@@ -101,7 +102,7 @@ public class ThroughputDriver implements IDriver
 	                     Storage storage )
 		throws RTIexception
 	{
-		logger = Logger.getLogger( "wantest" );
+		logger = LoggingConfigurator.getLogger( configuration.getFederateName() );
 		this.configuration = configuration;
 		this.rtiamb = rtiamb;
 		this.fedamb = fedamb;

--- a/codebase/src/java/wantest/wantest/throughput/ThroughputReportGenerator.java
+++ b/codebase/src/java/wantest/wantest/throughput/ThroughputReportGenerator.java
@@ -32,6 +32,7 @@ import wantest.Storage;
 import wantest.TestFederate;
 import wantest.Utils;
 import wantest.config.Configuration;
+import wantest.config.LoggingConfigurator;
 import wantest.events.DiscoverEvent;
 import wantest.events.Event;
 import wantest.events.Event.Type;
@@ -60,7 +61,7 @@ public class ThroughputReportGenerator
 	//----------------------------------------------------------
 	public ThroughputReportGenerator( Configuration configuration, Storage storage )
 	{
-		this.logger = Logger.getLogger( "wantest" );
+		this.logger = LoggingConfigurator.getLogger( configuration.getFederateName() );
 		this.configuration = configuration;
 		this.storage = storage;
 	}


### PR DESCRIPTION
Added support for the JVM binding. To use this, users just add the `--jvm` tag to the end of the command line. This will start all listed federates (the current and all peers) in separate threads inside the current JVM and turn on the JVM binding in code.
